### PR TITLE
Update README to remove trophy and repo sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,9 @@
 ![](https://nirzak-streak-stats.vercel.app/?user=anjani161161&theme=dark&hide_border=false)<br/>
 ![](https://github-readme-stats.vercel.app/api/top-langs/?username=anjani161161&theme=dark&hide_border=false&include_all_commits=false&count_private=false&layout=compact)
 
-## 🏆 GitHub Trophies
-![](https://github-profile-trophy.vercel.app/?username=anjani161161&theme=radical&no-frame=false&no-bg=true&margin-w=4)
 
 ### ✍️ Random Dev Quote
 ![](https://quotes-github-readme.vercel.app/api?type=horizontal&theme=radical)
-
-### 🔝 Top Contributed Repo
-![](https://github-contributor-stats.vercel.app/api?username=anjani161161&limit=5&theme=dark&combine_all_yearly_contributions=true)
 
 ---
 [![](https://visitcount.itsvg.in/api?id=anjani161161&icon=0&color=0)](https://visitcount.itsvg.in)


### PR DESCRIPTION
Removed GitHub Trophies and Top Contributed Repo sections from README.